### PR TITLE
[chore] Fix linting in atomic-notes-preview.tsx

### DIFF
--- a/components/atomic-notes-preview.tsx
+++ b/components/atomic-notes-preview.tsx
@@ -66,8 +66,8 @@ export default function AtomicNotesPreview({
 
   const handleApprove = () => {
     const approved = potentialNotes
-      .map((note, index) => ({
-        title: note.title,
+      .map(({ title }, index) => ({
+        title: title,
         content: getNoteContent(index)
       }))
       .filter((_, index) => selectedNotes.has(index));


### PR DESCRIPTION
## Summary
This PR resolves a linting error in atomic-notes-preview.tsx to keep the codebase clean and compliant with formatting rules.

## Changes
- Minor code formatting fix
- No logic or UI changes

## Notes
This is a maintenance update. Safe to merge with no impact on functionality.